### PR TITLE
Use fkt.png as application logo

### DIFF
--- a/Logo/README.md
+++ b/Logo/README.md
@@ -1,1 +1,1 @@
-Place your logo image as 'logo.png' in this directory.
+Place your logo image as 'fkt.png' in this directory.

--- a/frontend/src/__tests__/Header.test.jsx
+++ b/frontend/src/__tests__/Header.test.jsx
@@ -1,5 +1,3 @@
-vi.mock('/logo.png', () => ({ default: '' }), { virtual: true })
-
 import { render, screen, fireEvent } from '@testing-library/react'
 import Header from '../components/Header'
 

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -9,7 +9,6 @@ import Brightness4Icon from '@mui/icons-material/Brightness4'
 import Brightness7Icon from '@mui/icons-material/Brightness7'
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import SettingsIcon from '@mui/icons-material/Settings'
-import logo from '/logo.png'
 
 function Header({ toggleColorMode, mode }) {
   const theme = useTheme()
@@ -26,7 +25,7 @@ function Header({ toggleColorMode, mode }) {
       }}
     >
       <Toolbar sx={{ minHeight: { xs: 64, sm: 80 } }}>
-        <Box component="img" src={logo} alt="Company Logo" sx={{ height: isMobile ? 40 : 50, mr: 2 }} />
+        <Box component="img" src="/fkt.png" alt="Company Logo" sx={{ height: isMobile ? 40 : 50, mr: 2 }} />
         <Typography
           variant={isMobile ? 'h6' : 'h5'}
           sx={{


### PR DESCRIPTION
## Summary
- document that the logo image should be named `fkt.png`
- point Header image source to `/fkt.png` without importing the file
- simplify Header test now that logo import is a static path

## Testing
- `python -m unittest discover`
- `npm test --silent` *(fails: AnalysisForm.test.jsx and related tests)*
- `npm test --silent src/__tests__/Header.test.jsx`


------
https://chatgpt.com/codex/tasks/task_b_68b72b82b93c832fbe439cab92d399b7