### PR TITLE
feat: make guides and prompts configurable

### DIFF
--- a/Guidelines/default/5N1K_Guide.json
+++ b/Guidelines/default/5N1K_Guide.json
@@ -1,0 +1,66 @@
+{
+  "method": "5N1K (5W1H)",
+  "description": "Bir problemi tüm yönleriyle incelemek için kullanılan klasik sorgulama metodudur. Olayın bağlamını anlamak, kök nedenlere inmek ve çözüm sürecini başlatmak için kullanılır.",
+  "fields": [
+    {
+      "id": "What",
+      "title": "Ne? (What)",
+      "definition": "Problemin ne olduğunu açıkça tanımlayın. Hangi olay, durum veya hata ile karşılaşıldı?",
+      "example_questions": [
+        "Ne oldu?",
+        "Hangi ürün veya süreç etkilendi?",
+        "Hata tam olarak nasıl tanımlanabilir?"
+      ]
+    },
+    {
+      "id": "Where",
+      "title": "Nerede? (Where)",
+      "definition": "Problemin nerede meydana geldiğini belirtin. Fiziksel konum, hat veya dijital bir sistem olabilir.",
+      "example_questions": [
+        "Problem nerede meydana geldi?",
+        "Üretim hattının hangi bölümünde oluştu?",
+        "Hangi müşteri veya lokasyon etkilendi?"
+      ]
+    },
+    {
+      "id": "When",
+      "title": "Ne zaman? (When)",
+      "definition": "Problemin ne zaman ortaya çıktığını belirtin. Zaman aralığı, üretim tarihi, vardiya gibi detayları kapsar.",
+      "example_questions": [
+        "Problem ne zaman fark edildi?",
+        "İlk ne zaman oluştuğu biliniyor mu?",
+        "Belirli bir tarih veya vardiya ile ilişkili mi?"
+      ]
+    },
+    {
+      "id": "Who",
+      "title": "Kim? (Who)",
+      "definition": "Problemin kim tarafından fark edildiği ya da etkilediği kişileri tanımlayın.",
+      "example_questions": [
+        "Kim problemi ilk fark etti?",
+        "Kimler etkilenmiş olabilir?",
+        "Problemle ilgili çalışan, müşteri ya da tedarikçi var mı?"
+      ]
+    },
+    {
+      "id": "Why",
+      "title": "Neden? (Why)",
+      "definition": "Problemin ortaya çıkma sebepleri üzerine düşünün. Kök nedenlerin ipuçları burada aranır.",
+      "example_questions": [
+        "Neden bu problem oluştu?",
+        "Altta yatan nedenler neler olabilir?",
+        "Benzer problemler daha önce yaşandı mı?"
+      ]
+    },
+    {
+      "id": "How",
+      "title": "Nasıl? (How)",
+      "definition": "Problemin nasıl geliştiğini, sürecin nasıl işlediğini ve ne şekilde sonuçlandığını açıklayın.",
+      "example_questions": [
+        "Bu problem nasıl ortaya çıktı?",
+        "Olaylar hangi sırayla gelişti?",
+        "Şu an problem nasıl etkiler yaratıyor?"
+      ]
+    }
+  ]
+}

--- a/Guidelines/default/8D_Guide.json
+++ b/Guidelines/default/8D_Guide.json
@@ -1,0 +1,46 @@
+{
+  "method": "8D",
+  "description": "8D (Eight Disciplines) metodu, ürün ve süreç kaynaklı problemleri sistematik şekilde çözmek için geliştirilmiş etkili bir problem çözme tekniğidir. Özellikle otomotiv ve üretim sektöründe yaygındır.",
+  "steps": [
+    {
+      "step": "D1",
+      "title": "Ekip Oluşturma",
+      "detail": "Problemi analiz etmek ve çözmek için farklı disiplinlerden, konuyla ilgili bilgi ve yetkinliğe sahip bir ekip oluşturulur. Ekip üyeleri sorumluluklarına göre atanır."
+    },
+    {
+      "step": "D2",
+      "title": "Problemin Tanımı",
+      "detail": "Problem açık, ölçülebilir ve objektif kriterlerle tanımlanır. Müşteri şikayeti, ürün adı, tarih, yer, miktar gibi detaylara yer verilir. 5N1K sorularıyla desteklenmesi önerilir."
+    },
+    {
+      "step": "D3",
+      "title": "Geçici Önlemler",
+      "detail": "Problemin müşteriyi ya da süreci daha fazla etkilemesini önlemek amacıyla geçici, hızlı çözümler uygulanır. Bu önlemlerin etkili olduğu doğrulanmalıdır."
+    },
+    {
+      "step": "D4",
+      "title": "Kök Neden Analizi",
+      "detail": "Problemin temel nedenleri araştırılır. Yüzeysel belirtiler değil, problemi gerçekten yaratan neden(ler) tespit edilir. '5 Neden' tekniği, balık kılçığı diyagramı gibi araçlar kullanılabilir."
+    },
+    {
+      "step": "D5",
+      "title": "Kalıcı Çözüm Geliştirme",
+      "detail": "Kök nedenlere yönelik kalıcı çözüm önerileri oluşturulur. Bu çözümlerin uygulanabilirliği, riskleri ve etkisi değerlendirilerek en uygun çözüm seçilir."
+    },
+    {
+      "step": "D6",
+      "title": "Kalıcı Çözümün Uygulanması",
+      "detail": "Seçilen kalıcı çözüm(ler) sahada uygulanır. Uygulama sonrası doğrulama yapılır, gerekiyorsa düzeltici aksiyonlar alınır. Etkinlik kontrolü bu aşamada önemlidir."
+    },
+    {
+      "step": "D7",
+      "title": "Önleyici Faaliyetler",
+      "detail": "Benzer problemlerin başka ürün, proses ya da alanlarda tekrarlanmaması için sistematik önleyici faaliyetler planlanır ve uygulanır. Proaktif kalite anlayışı burada devrededir."
+    },
+    {
+      "step": "D8",
+      "title": "Takdir ve Kapanış",
+      "detail": "Ekip üyeleri, çözüm sürecine katkılarından dolayı takdir edilir. Tüm dokümantasyon tamamlanır ve süreç resmi olarak kapatılır. Öğrenilen dersler paylaşılır."
+    }
+  ]
+}

--- a/Guidelines/default/A3_Guide.json
+++ b/Guidelines/default/A3_Guide.json
@@ -1,0 +1,84 @@
+{
+  "method": "A3 Problem Solving",
+  "description": "A3 Problem Solving, problemi sistematik biçimde tanımlamak, analiz etmek ve çözüm geliştirmek için kullanılan yalın düşünce temelli bir yaklaşımdır. A3 formatında tek sayfalık bir raporla ilerlenir.",
+  "fields": [
+    {
+      "id": "Background",
+      "title": "Arka Plan (Background)",
+      "definition": "Problemin bağlamını, tarihçesini ve neden ele alındığını açıklayın.",
+      "example_questions": [
+        "Bu konu neden önemli?",
+        "Bu problem nerede, ne zaman ve kim tarafından fark edildi?",
+        "Şu anki durum neden sürdürülemez?"
+      ]
+    },
+    {
+      "id": "CurrentSituation",
+      "title": "Mevcut Durum (Current Situation)",
+      "definition": "Süreç haritası, veri ve gözlemlerle mevcut durumu açıkça tanımlayın.",
+      "example_questions": [
+        "Şu anda neler oluyor?",
+        "Performans ölçümleri ne gösteriyor?",
+        "İlgili süreç adımları neler?"
+      ]
+    },
+    {
+      "id": "ProblemStatement",
+      "title": "Problem Tanımı (Problem Statement)",
+      "definition": "Belirli, ölçülebilir ve zaman odaklı bir problem tanımı oluşturun.",
+      "example_questions": [
+        "Problem nedir ve neden acildir?",
+        "Problem ifadesi müşteri odaklı mı?",
+        "Hedef ve mevcut durum arasında ne fark var?"
+      ]
+    },
+    {
+      "id": "Goal",
+      "title": "Hedef (Goal)",
+      "definition": "Başarının nasıl tanımlanacağını belirleyin.",
+      "example_questions": [
+        "Problem çözüldüğünde nasıl bir sonuç bekleniyor?",
+        "Zaman çizelgesi ve hedef değer nedir?"
+      ]
+    },
+    {
+      "id": "RootCauseAnalysis",
+      "title": "Kök Neden Analizi (Root Cause Analysis)",
+      "definition": "Probleme neden olan temel sebepleri araştırın.",
+      "example_questions": [
+        "5N neden sorusu kullanıldı mı?",
+        "Ishikawa/Fishbone diyagramı oluşturuldu mu?",
+        "Kök neden veriye dayanıyor mu?"
+      ]
+    },
+    {
+      "id": "Countermeasures",
+      "title": "Karşı Önlemler (Countermeasures)",
+      "definition": "Kök nedenleri ortadan kaldıracak çözüm önerilerini tanımlayın.",
+      "example_questions": [
+        "Önerilen önlemler doğrudan kök nedenlere mi hitap ediyor?",
+        "Alternatif çözümler değerlendirildi mi?",
+        "Etki ve uygulanabilirlik analizleri yapıldı mı?"
+      ]
+    },
+    {
+      "id": "ImplementationPlan",
+      "title": "Uygulama Planı (Implementation Plan)",
+      "definition": "Çözüm önerilerinin kim tarafından, ne zaman, nasıl uygulanacağını belirtin.",
+      "example_questions": [
+        "Görev dağılımı yapıldı mı?",
+        "Uygulama süresi, kaynaklar ve sorumlular belirlendi mi?"
+      ]
+    },
+    {
+      "id": "FollowUp",
+      "title": "Takip & Doğrulama (Follow-Up)",
+      "definition": "Sonuçlar izlenir, iyileştirme kalıcı hale getirilir.",
+      "example_questions": [
+        "Uygulamalar sonrası performans izlendi mi?",
+        "Standartlar güncellendi mi?",
+        "Yeni öğrenimler paylaşıldı mı?"
+      ]
+    }
+  ]
+}

--- a/Guidelines/default/DMAIC_Guide.json
+++ b/Guidelines/default/DMAIC_Guide.json
@@ -1,0 +1,56 @@
+{
+  "method": "DMAIC",
+  "description": "DMAIC, süreç iyileştirme için kullanılan sistematik bir problem çözme metodudur. Tanımla, Ölç, Analiz Et, İyileştir ve Kontrol Et adımlarından oluşur.",
+  "fields": [
+    {
+      "id": "Define",
+      "title": "Tanımla (Define)",
+      "definition": "Problemi, süreci ve müşteri beklentilerini net olarak tanımlayın.",
+      "example_questions": [
+        "Müşteri kim ve beklentisi nedir?",
+        "Problemin kapsamı ve sınırları neler?",
+        "İyileştirilecek sürecin mevcut durumu nedir?"
+      ]
+    },
+    {
+      "id": "Measure",
+      "title": "Ölç (Measure)",
+      "definition": "Mevcut süreci ölçün ve problemin boyutunu sayısal verilerle ortaya koyun.",
+      "example_questions": [
+        "Hangi performans ölçütleri kullanılmalı?",
+        "Veri toplama planı oluşturuldu mu?",
+        "Mevcut performans ne düzeyde?"
+      ]
+    },
+    {
+      "id": "Analyze",
+      "title": "Analiz Et (Analyze)",
+      "definition": "Problemin kök nedenlerini analiz edin ve etkileyen değişkenleri belirleyin.",
+      "example_questions": [
+        "Mevcut süreç neden bu performansı gösteriyor?",
+        "Varyasyonun kaynakları neler?",
+        "Kritik girdiler nelerdir?"
+      ]
+    },
+    {
+      "id": "Improve",
+      "title": "İyileştir (Improve)",
+      "definition": "Kök nedenleri ortadan kaldırmak için çözümler üretin ve test edin.",
+      "example_questions": [
+        "Hangi iyileştirme fikirleri üretildi?",
+        "Deneme uygulamaları ne sonuç verdi?",
+        "Risk analizi yapıldı mı?"
+      ]
+    },
+    {
+      "id": "Control",
+      "title": "Kontrol Et (Control)",
+      "definition": "Uygulanan çözümlerin kalıcı olmasını sağlamak için kontroller kurun.",
+      "example_questions": [
+        "Yeni sürecin performansı nasıl izlenecek?",
+        "Standart prosedürler güncellendi mi?",
+        "Süreç sapmaları nasıl ele alınacak?"
+      ]
+    }
+  ]
+}

--- a/Guidelines/default/Ishikawa_Guide.json
+++ b/Guidelines/default/Ishikawa_Guide.json
@@ -1,0 +1,66 @@
+{
+  "method": "Ishikawa (Balık Kılçığı) Diyagramı",
+  "description": "Problemin kök nedenlerini sistematik bir şekilde analiz etmek için kullanılan neden-sonuç diyagramıdır. Ana kategoriler altında olası tüm nedenler sorgulanır.",
+  "fields": [
+    {
+      "id": "Man",
+      "title": "İnsan (Man)",
+      "definition": "Problemin oluşmasında etkili olabilecek insan hataları veya yetkinlik eksiklikleri.",
+      "example_questions": [
+        "Çalışanlar doğru şekilde eğitilmiş miydi?",
+        "Görevler net ve anlaşılır mıydı?",
+        "İnsan faktörü süreci nasıl etkiledi?"
+      ]
+    },
+    {
+      "id": "Machine",
+      "title": "Makine (Machine)",
+      "definition": "Kullanılan ekipman, araç veya makinelerin problemin nedeni olup olmadığını değerlendirin.",
+      "example_questions": [
+        "Makine veya ekipman arızalı mıydı?",
+        "Bakım geçmişi düzenli miydi?",
+        "Kullanılan teknolojide bir sınır ya da kusur var mı?"
+      ]
+    },
+    {
+      "id": "Method",
+      "title": "Yöntem (Method)",
+      "definition": "Uygulanan prosedürler, talimatlar ve yöntemlerin problemin nedeni olup olmadığını analiz edin.",
+      "example_questions": [
+        "İş talimatları net miydi?",
+        "Standart işletim prosedürleri uygun muydu?",
+        "İzlenen yöntem soruna katkıda bulunmuş olabilir mi?"
+      ]
+    },
+    {
+      "id": "Material",
+      "title": "Malzeme (Material)",
+      "definition": "Kullanılan hammadde, yarı mamul veya son ürünle ilgili kalite sorunlarını araştırın.",
+      "example_questions": [
+        "Malzeme spesifikasyonlara uygun muydu?",
+        "Kalitesiz ya da hatalı malzeme kullanılmış olabilir mi?",
+        "Tedarik zincirinden gelen sorun var mı?"
+      ]
+    },
+    {
+      "id": "Measurement",
+      "title": "Ölçüm (Measurement)",
+      "definition": "Kalite kontrol, ölçüm ekipmanları ve veri toplama yöntemlerinin doğruluğunu sorgulayın.",
+      "example_questions": [
+        "Ölçüm araçları kalibre edilmiş miydi?",
+        "Doğru veri toplandı mı?",
+        "Analiz hatası olasılığı var mı?"
+      ]
+    },
+    {
+      "id": "Environment",
+      "title": "Çevre (Environment)",
+      "definition": "Fiziksel çevre koşulları (ısı, nem, gürültü, ışık) veya iş ortamının problemi nasıl etkilediğini değerlendirin.",
+      "example_questions": [
+        "Çalışma ortamı uygun muydu?",
+        "Dış etkenler (mevsim, toz, nem) süreci etkiliyor olabilir mi?",
+        "İklimsel veya bölgesel koşullar göz önüne alındı mı?"
+      ]
+    }
+  ]
+}

--- a/PromptManager/__init__.py
+++ b/PromptManager/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 from typing import Any, Dict
 
@@ -39,10 +40,31 @@ class PromptManager:
             base_dir = Path(__file__).resolve().parents[1] / "Prompts"
             prompt_path = base_dir / f"{method}_Prompt.txt"
             if prompt_path.exists():
-                self._text_cache[method] = self.load_text_prompt(str(prompt_path))
+                path_str = str(prompt_path)
+                self._text_cache[method] = self.load_text_prompt(path_str)
             else:
                 self._text_cache[method] = ""
         return self._text_cache[method]
+
+    def save_text_prompt(self, method: str, text: str) -> None:
+        """Persist ``text`` for ``method`` and update the cache."""
+        base_dir = Path(__file__).resolve().parents[1] / "Prompts"
+        prompt_path = base_dir / f"{method}_Prompt.txt"
+        with open(prompt_path, "w", encoding="utf-8") as file:
+            file.write(text)
+        self._text_cache[method] = text
+
+    def reset_text_prompt(self, method: str) -> None:
+        """Restore ``method`` prompt from the ``default`` directory."""
+        base_dir = Path(__file__).resolve().parents[1] / "Prompts"
+        default_dir = base_dir / "default"
+        src = default_dir / f"{method}_Prompt.txt"
+        dst = base_dir / f"{method}_Prompt.txt"
+        if not src.exists():
+            raise FileNotFoundError(src)
+        shutil.copy2(src, dst)
+        if method in self._text_cache:
+            del self._text_cache[method]
 
 
 __all__ = ["PromptManager"]

--- a/Prompts/default/5N1K_Prompt.txt
+++ b/Prompts/default/5N1K_Prompt.txt
@@ -1,0 +1,27 @@
+Sen deneyimli bir kalite mühendisisin. Aşağıdaki müşteri şikayetine göre 5N1K analizine dayalı detaylı bir problem çözüm raporu oluştur.
+
+Müşteri Şikayeti: {{musteri_sikayeti}}  
+Parça Kodu: {{parca_kodu}}  
+Problem Açıklaması: {{problem_aciklamasi}}  
+
+Rapor şu başlıklara uygun olarak yazılmalıdır:
+
+1. Ne? (What)  
+[...]  
+
+2. Nerede? (Where)  
+[...]  
+
+3. Ne zaman? (When)  
+[...]  
+
+4. Kim? (Who)  
+[...]  
+
+5. Nasıl? (How)  
+[...]  
+
+6. Neden? (Why)  
+[...]  
+
+❗️Yalnızca yukarıdaki başlıklara uygun teknik içerik üret. Giriş paragrafı, metodoloji açıklaması ya da genel değerlendirme yazma. Her başlığı **sadece ilgili içerikle** doldur. Ekstra bilgi verme, raporu tek seferde üret.

--- a/Prompts/default/A3_Prompt.txt
+++ b/Prompts/default/A3_Prompt.txt
@@ -1,0 +1,30 @@
+Sen deneyimli bir kalite mühendisisin. Aşağıdaki müşteri şikayetine göre A3 Problem Çözme metodolojisine uygun teknik ve detaylı bir rapor hazırla.
+
+Müşteri Şikayeti: {{musteri_sikayeti}}  
+Parça Kodu: {{parca_kodu}}  
+Problem Açıklaması: {{problem_aciklamasi}}  
+
+Rapor şu başlıklara uygun olarak yazılmalıdır:
+
+1. Arka Plan  
+[...]  
+
+2. Mevcut Durum  
+[...]  
+
+3. Hedef Durum  
+[...]  
+
+4. Kök Neden Analizi  
+[...]  
+
+5. Karşı Önlemler  
+[...]  
+
+6. Uygulama Planı  
+[...]  
+
+7. Takip ve Sonuçlar  
+[...]  
+
+❗️Yalnızca yukarıdaki başlıklara uygun teknik içerik üret. Giriş paragrafı, metodoloji açıklaması ya da genel değerlendirme yazma. Her başlığı **sadece ilgili içerikle** doldur. Ekstra bilgi verme, raporu tek seferde üret.

--- a/Prompts/default/DMAIC_Prompt.txt
+++ b/Prompts/default/DMAIC_Prompt.txt
@@ -1,0 +1,24 @@
+Sen deneyimli bir kalite mühendisisin. Aşağıdaki müşteri şikayetine göre DMAIC metodolojisine uygun teknik ve detaylı bir analiz raporu oluştur.
+
+Müşteri Şikayeti: {{musteri_sikayeti}}  
+Parça Kodu: {{parca_kodu}}  
+Problem Açıklaması: {{problem_aciklamasi}}  
+
+Rapor şu başlıklara uygun olarak yazılmalıdır:
+
+1. Tanımla (Define)  
+[...]  
+
+2. Ölç (Measure)  
+[...]  
+
+3. Analiz Et (Analyze)  
+[...]  
+
+4. İyileştir (Improve)  
+[...]  
+
+5. Kontrol Et (Control)  
+[...]  
+
+❗️Yalnızca yukarıdaki başlıklara uygun teknik içerik üret. Giriş paragrafı, metodoloji açıklaması ya da genel değerlendirme yazma. Her başlığı **sadece ilgili içerikle** doldur. Ekstra bilgi verme, raporu tek seferde üret.

--- a/Prompts/default/Fixer_General_Prompt.md
+++ b/Prompts/default/Fixer_General_Prompt.md
@@ -1,0 +1,4 @@
+Review the following report for clarity and correctness.
+Return the improved text only in {language}.
+
+{initial_report_text}

--- a/Prompts/default/Ishikawa_Prompt.txt
+++ b/Prompts/default/Ishikawa_Prompt.txt
@@ -1,0 +1,27 @@
+Sen deneyimli bir kalite mühendisisin. Aşağıdaki müşteri şikayetine göre Ishikawa (Balık Kılçığı) metoduna uygun teknik bir analiz raporu hazırla.
+
+Müşteri Şikayeti: {{musteri_sikayeti}}  
+Parça Kodu: {{parca_kodu}}  
+Problem Açıklaması: {{problem_aciklamasi}}  
+
+Rapor şu başlıklara uygun olarak yazılmalıdır:
+
+1. İnsan (Man)  
+[...]  
+
+2. Makine (Machine)  
+[...]  
+
+3. Malzeme (Material)  
+[...]  
+
+4. Metot (Method)  
+[...]  
+
+5. Çevre (Environment)  
+[...]  
+
+6. Ölçüm (Measurement)  
+[...]  
+
+❗️Yalnızca yukarıdaki başlıklara uygun teknik içerik üret. Giriş paragrafı, metodoloji açıklaması ya da genel değerlendirme yazma. Her başlığı **sadece ilgili içerikle** doldur. Ekstra bilgi verme, raporu tek seferde üret.

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,8 +1,22 @@
 const { app, BrowserWindow } = require('electron');
-const { spawn } = require('child_process');
+const { spawn, spawnSync } = require('child_process');
 const path = require('path');
+const fs = require('fs');
+const dotenv = require('dotenv');
 
 let pythonProcess;
+
+function ensureEnv() {
+    const envPath = path.join(__dirname, '..', '.env');
+    let config = {};
+    if (fs.existsSync(envPath)) {
+        config = dotenv.parse(fs.readFileSync(envPath));
+    }
+    if (!config.OPENAI_API_KEY || !config.CLAIMS_FILE_PATH || !config.OPENAI_MODEL) {
+        const script = path.join(__dirname, '..', 'configure_env.py');
+        spawnSync('python', [script], { stdio: 'inherit' });
+    }
+}
 
 function createWindow() {
     const mainWindow = new BrowserWindow({
@@ -19,6 +33,7 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
+    ensureEnv();
     const exeName = process.platform === 'win32' ? 'run_api.exe' : 'run_api';
     const exePath = path.join(__dirname, 'backend', exeName);
     pythonProcess = spawn(exePath, [], {

--- a/electron/package.json
+++ b/electron/package.json
@@ -9,6 +9,7 @@
     "postinstall": "npm run build:backend"
   },
   "dependencies": {
+    "dotenv": "^16.4.5",
     "electron": "^30.0.0"
   },
   "devDependencies": {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,9 +3,13 @@ import { ThemeProvider, createTheme } from '@mui/material/styles'
 import CssBaseline from '@mui/material/CssBaseline'
 import Home from './pages/Home'
 import Header from './components/Header'
+import GuidelineEditorModal from './components/GuidelineEditorModal'
+import PromptEditorModal from './components/PromptEditorModal'
 
 function App() {
   const [mode, setMode] = useState('light')
+  const [guideOpen, setGuideOpen] = useState(false)
+  const [promptOpen, setPromptOpen] = useState(false)
   const toggleColorMode = () => {
     setMode((prev) => (prev === 'light' ? 'dark' : 'light'))
   }
@@ -40,8 +44,15 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <Header toggleColorMode={toggleColorMode} mode={mode} />
+      <Header
+        toggleColorMode={toggleColorMode}
+        mode={mode}
+        onOpenGuide={() => setGuideOpen(true)}
+        onOpenPrompt={() => setPromptOpen(true)}
+      />
       <Home />
+      <GuidelineEditorModal open={guideOpen} onClose={() => setGuideOpen(false)} />
+      <PromptEditorModal open={promptOpen} onClose={() => setPromptOpen(false)} />
     </ThemeProvider>
   )
 }

--- a/frontend/src/components/GuidelineEditorModal.jsx
+++ b/frontend/src/components/GuidelineEditorModal.jsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react'
+import { Modal, Box, Typography, IconButton, TextField, Button } from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
+
+function GuidelineEditorModal({ open, onClose, method = '8D' }) {
+  const [content, setContent] = useState('')
+
+  useEffect(() => {
+    if (open) {
+      fetch(`/guide/${method}`)
+        .then((res) => res.json())
+        .then((data) => setContent(JSON.stringify(data, null, 2)))
+    }
+  }, [open, method])
+
+  const handleSave = () => {
+    fetch(`/guide/${method}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ data: JSON.parse(content) })
+    }).then(onClose)
+  }
+
+  const handleReset = () => {
+    fetch(`/guide/${method}/reset`, { method: 'POST' })
+      .then(() => fetch(`/guide/${method}`))
+      .then((res) => res.json())
+      .then((data) => setContent(JSON.stringify(data, null, 2)))
+  }
+
+  return (
+    <Modal open={open} onClose={onClose} aria-labelledby="guideline-editor-title">
+      <Box sx={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', bgcolor: 'background.paper', boxShadow: 24, p: 3, borderRadius: 2, width: '80%', maxWidth: 700 }}>
+        <IconButton aria-label="close" onClick={onClose} sx={{ position: 'absolute', top: 8, right: 8 }}>
+          <CloseIcon />
+        </IconButton>
+        <Typography id="guideline-editor-title" variant="h6" sx={{ mb: 2 }}>
+          {method} Guideline
+        </Typography>
+        <TextField multiline fullWidth minRows={12} value={content} onChange={(e) => setContent(e.target.value)} sx={{ mb: 2 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <Button onClick={handleReset} color="secondary" sx={{ mr: 1 }}>
+            Reset
+          </Button>
+          <Button onClick={handleSave} variant="contained">
+            Save
+          </Button>
+        </Box>
+      </Box>
+    </Modal>
+  )
+}
+
+export default GuidelineEditorModal

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -9,8 +9,10 @@ import Brightness4Icon from '@mui/icons-material/Brightness4'
 import Brightness7Icon from '@mui/icons-material/Brightness7'
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import SettingsIcon from '@mui/icons-material/Settings'
+import MenuBookIcon from '@mui/icons-material/MenuBook'
+import EditNoteIcon from '@mui/icons-material/EditNote'
 
-function Header({ toggleColorMode, mode }) {
+function Header({ toggleColorMode, mode, onOpenGuide, onOpenPrompt }) {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
 
@@ -36,6 +38,12 @@ function Header({ toggleColorMode, mode }) {
         >
           DB Kalite Asistanı
         </Typography>
+        <IconButton color="inherit" aria-label="guide" onClick={onOpenGuide} sx={{ mx: 0.5, transition: 'transform 0.2s', '&:hover': { transform: 'scale(1.1)' } }}>
+          <MenuBookIcon />
+        </IconButton>
+        <IconButton color="inherit" aria-label="prompt" onClick={onOpenPrompt} sx={{ mx: 0.5, transition: 'transform 0.2s', '&:hover': { transform: 'scale(1.1)' } }}>
+          <EditNoteIcon />
+        </IconButton>
         <IconButton color="inherit" aria-label="help" sx={{ mx: 0.5, transition: 'transform 0.2s', '&:hover': { transform: 'scale(1.1)' } }}>
           <HelpOutlineIcon />
         </IconButton>

--- a/frontend/src/components/PromptEditorModal.jsx
+++ b/frontend/src/components/PromptEditorModal.jsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react'
+import { Modal, Box, Typography, IconButton, TextField, Button } from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
+
+function PromptEditorModal({ open, onClose, method = 'A3' }) {
+  const [content, setContent] = useState('')
+
+  useEffect(() => {
+    if (open) {
+      fetch(`/prompt/${method}`)
+        .then((res) => res.json())
+        .then((data) => setContent(data.text))
+    }
+  }, [open, method])
+
+  const handleSave = () => {
+    fetch(`/prompt/${method}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: content })
+    }).then(onClose)
+  }
+
+  const handleReset = () => {
+    fetch(`/prompt/${method}/reset`, { method: 'POST' })
+      .then(() => fetch(`/prompt/${method}`))
+      .then((res) => res.json())
+      .then((data) => setContent(data.text))
+  }
+
+  return (
+    <Modal open={open} onClose={onClose} aria-labelledby="prompt-editor-title">
+      <Box sx={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', bgcolor: 'background.paper', boxShadow: 24, p: 3, borderRadius: 2, width: '80%', maxWidth: 700 }}>
+        <IconButton aria-label="close" onClick={onClose} sx={{ position: 'absolute', top: 8, right: 8 }}>
+          <CloseIcon />
+        </IconButton>
+        <Typography id="prompt-editor-title" variant="h6" sx={{ mb: 2 }}>
+          {method} Prompt
+        </Typography>
+        <TextField multiline fullWidth minRows={12} value={content} onChange={(e) => setContent(e.target.value)} sx={{ mb: 2 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <Button onClick={handleReset} color="secondary" sx={{ mr: 1 }}>
+            Reset
+          </Button>
+          <Button onClick={handleSave} variant="contained">
+            Save
+          </Button>
+        </Box>
+      </Box>
+    </Modal>
+  )
+}
+
+export default PromptEditorModal

--- a/tests/test_prompt_manager.py
+++ b/tests/test_prompt_manager.py
@@ -38,6 +38,23 @@ class PromptManagerTextTest(unittest.TestCase):
             self.assertEqual(m.call_count, 1)
             self.assertIs(first, second)
 
+    def test_save_and_reset_text_prompt(self) -> None:
+        target = self.base_dir / "A3_Prompt.txt"
+        backup = target.with_suffix(".bak")
+        target.rename(backup)
+        try:
+            self.manager.save_text_prompt("A3", "test")
+            self.assertEqual(self.manager.get_text_prompt("A3"), "test")
+            self.manager.reset_text_prompt("A3")
+            with open(target, "r", encoding="utf-8") as f:
+                restored = f.read()
+            default_path = self.base_dir / "default" / "A3_Prompt.txt"
+            with open(default_path, "r", encoding="utf-8") as f:
+                default = f.read()
+            self.assertEqual(restored, default)
+        finally:
+            backup.rename(target)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- load and store guides via new `GuideManager` utilities and defaults
- manage text prompts with reset and save handlers
- expose API and UI to edit or restore guides and prompts
- ensure Electron setup collects API key and complaint file

## Testing
- `pre-commit run --files GuideManager/__init__.py PromptManager/__init__.py api/__init__.py electron/main.js electron/package.json frontend/src/App.jsx frontend/src/components/Header.jsx frontend/src/components/GuidelineEditorModal.jsx frontend/src/components/PromptEditorModal.jsx tests/test_guide_manager.py tests/test_prompt_manager.py`
- `python -m unittest discover`
- `npm test` *(fails: 5 failing tests)*

------
https://chatgpt.com/codex/tasks/task_b_68b750f78d78832fa3d9c62fb562092e