### PR TITLE
Connect top bar editors to backend and load defaults

### DIFF
--- a/frontend/src/__tests__/GuidelineEditorModal.test.jsx
+++ b/frontend/src/__tests__/GuidelineEditorModal.test.jsx
@@ -1,0 +1,23 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import GuidelineEditorModal from '../components/GuidelineEditorModal'
+import { API_BASE } from '../api'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+test('loads guideline content on open', async () => {
+  const mockData = { step: 'Test' }
+  vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+    json: () => Promise.resolve(mockData)
+  })
+  render(<GuidelineEditorModal open onClose={() => {}} method="8D" />)
+  await waitFor(() =>
+    expect(global.fetch).toHaveBeenCalledWith(`${API_BASE}/guide/8D`)
+  )
+  await waitFor(() =>
+    expect(screen.getByRole('textbox')).toHaveValue(
+      JSON.stringify(mockData, null, 2)
+    )
+  )
+})

--- a/frontend/src/__tests__/PromptEditorModal.test.jsx
+++ b/frontend/src/__tests__/PromptEditorModal.test.jsx
@@ -1,0 +1,19 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import PromptEditorModal from '../components/PromptEditorModal'
+import { API_BASE } from '../api'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+test('loads prompt text on open', async () => {
+  const text = 'Example prompt'
+  vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+    json: () => Promise.resolve({ text })
+  })
+  render(<PromptEditorModal open onClose={() => {}} method="A3" />)
+  await waitFor(() =>
+    expect(global.fetch).toHaveBeenCalledWith(`${API_BASE}/prompt/A3`)
+  )
+  await waitFor(() => expect(screen.getByRole('textbox')).toHaveValue(text))
+})

--- a/frontend/src/components/GuidelineEditorModal.jsx
+++ b/frontend/src/components/GuidelineEditorModal.jsx
@@ -1,20 +1,21 @@
 import React, { useEffect, useState } from 'react'
 import { Modal, Box, Typography, IconButton, TextField, Button } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
+import { API_BASE } from '../api'
 
 function GuidelineEditorModal({ open, onClose, method = '8D' }) {
   const [content, setContent] = useState('')
 
   useEffect(() => {
     if (open) {
-      fetch(`/guide/${method}`)
+      fetch(`${API_BASE}/guide/${method}`)
         .then((res) => res.json())
         .then((data) => setContent(JSON.stringify(data, null, 2)))
     }
   }, [open, method])
 
   const handleSave = () => {
-    fetch(`/guide/${method}`, {
+    fetch(`${API_BASE}/guide/${method}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ data: JSON.parse(content) })
@@ -22,8 +23,8 @@ function GuidelineEditorModal({ open, onClose, method = '8D' }) {
   }
 
   const handleReset = () => {
-    fetch(`/guide/${method}/reset`, { method: 'POST' })
-      .then(() => fetch(`/guide/${method}`))
+    fetch(`${API_BASE}/guide/${method}/reset`, { method: 'POST' })
+      .then(() => fetch(`${API_BASE}/guide/${method}`))
       .then((res) => res.json())
       .then((data) => setContent(JSON.stringify(data, null, 2)))
   }

--- a/frontend/src/components/PromptEditorModal.jsx
+++ b/frontend/src/components/PromptEditorModal.jsx
@@ -1,20 +1,21 @@
 import React, { useEffect, useState } from 'react'
 import { Modal, Box, Typography, IconButton, TextField, Button } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
+import { API_BASE } from '../api'
 
 function PromptEditorModal({ open, onClose, method = 'A3' }) {
   const [content, setContent] = useState('')
 
   useEffect(() => {
     if (open) {
-      fetch(`/prompt/${method}`)
+      fetch(`${API_BASE}/prompt/${method}`)
         .then((res) => res.json())
         .then((data) => setContent(data.text))
     }
   }, [open, method])
 
   const handleSave = () => {
-    fetch(`/prompt/${method}`, {
+    fetch(`${API_BASE}/prompt/${method}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text: content })
@@ -22,8 +23,8 @@ function PromptEditorModal({ open, onClose, method = 'A3' }) {
   }
 
   const handleReset = () => {
-    fetch(`/prompt/${method}/reset`, { method: 'POST' })
-      .then(() => fetch(`/prompt/${method}`))
+    fetch(`${API_BASE}/prompt/${method}/reset`, { method: 'POST' })
+      .then(() => fetch(`${API_BASE}/prompt/${method}`))
       .then((res) => res.json())
       .then((data) => setContent(data.text))
   }


### PR DESCRIPTION
## Summary
- Load existing guideline and prompt content via API_BASE in top bar editors
- Add unit tests for guideline and prompt editor modals

## Testing
- `python -m unittest discover`
- `npm test --silent` *(fails: AnalysisForm.test.jsx > fetches filtered claims, handles single claim object response, shows debug alert after successful analyze, shows raw analysis json when response missing fields, shows raw claims json on unexpected response)*
- `npx vitest run src/__tests__/GuidelineEditorModal.test.jsx src/__tests__/PromptEditorModal.test.jsx`


------
https://chatgpt.com/codex/tasks/task_b_68b75c76c674832f8b6bafd62664c398