### PR TITLE
Enforce runtime ENV_FILE configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 # Virtual environment directories
 .venv/
 .env/
+.env
 venv/
 ENV/
 env/

--- a/run_api.py
+++ b/run_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import os
+import logging
 from dotenv import load_dotenv
 import uvicorn
 
@@ -13,18 +14,14 @@ from api import app
 
 
 def _load_env() -> None:
-    """Load environment variables from ``.env`` file."""
+    """Load environment variables from ``ENV_FILE`` if provided."""
     env_file = os.environ.get("ENV_FILE")
     if env_file and Path(env_file).is_file():
         load_dotenv(env_file)
-        return
-    appdata = os.getenv("APPDATA")
-    if appdata:
-        default_env = Path(appdata) / "DB-App" / ".env"
-        if default_env.is_file():
-            load_dotenv(default_env)
-            return
-    load_dotenv()
+        os.environ["CONFIG_MISSING"] = "0"
+    else:  # pragma: no cover - config missing path logging
+        logging.error("Environment file missing; set ENV_FILE to a valid .env path")
+        os.environ["CONFIG_MISSING"] = "1"
 
 
 def main() -> None:

--- a/tests/test_run_api.py
+++ b/tests/test_run_api.py
@@ -1,4 +1,6 @@
 import importlib
+import os
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -6,15 +8,39 @@ from unittest.mock import patch
 class RunAPITest(unittest.TestCase):
     """Tests for the ``run_api`` entry point."""
 
-    def test_main_invokes_uvicorn(self) -> None:
-        module = importlib.import_module("run_api")
-        with patch.object(module, "load_dotenv") as mock_load, \
-             patch.object(module, "uvicorn") as mock_uvicorn, \
-             patch.object(module, "configure_logging") as mock_conf:
-            module.main()
-            mock_conf.assert_called_once()
-            mock_load.assert_called_once()
-            mock_uvicorn.run.assert_called_once_with(module.app, host="0.0.0.0", port=8000)
+    def test_main_with_env_file(self) -> None:
+        """``main`` should load dotenv when ``ENV_FILE`` exists."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env_path = os.path.join(tmpdir, ".env")
+            with open(env_path, "w", encoding="utf-8") as fh:
+                fh.write("OPENAI_API_KEY=key")
+            with patch.dict(os.environ, {"ENV_FILE": env_path}, clear=True):
+                module = importlib.import_module("run_api")
+                with patch.object(module, "uvicorn") as mock_uvicorn, \
+                        patch.object(module, "configure_logging") as mock_conf, \
+                        patch.object(module, "load_dotenv") as mock_load:
+                    module.main()
+                    mock_conf.assert_called_once()
+                    mock_load.assert_called_once_with(env_path)
+                    mock_uvicorn.run.assert_called_once_with(
+                        module.app, host="0.0.0.0", port=8000
+                    )
+                    self.assertEqual(os.environ["CONFIG_MISSING"], "0")
+
+    def test_main_without_env_file(self) -> None:
+        """``main`` should not load dotenv when ``ENV_FILE`` is missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            module = importlib.import_module("run_api")
+            with patch.object(module, "uvicorn") as mock_uvicorn, \
+                    patch.object(module, "configure_logging") as mock_conf, \
+                    patch.object(module, "load_dotenv") as mock_load:
+                module.main()
+                mock_conf.assert_called_once()
+                mock_load.assert_not_called()
+                mock_uvicorn.run.assert_called_once_with(
+                    module.app, host="0.0.0.0", port=8000
+                )
+                self.assertEqual(os.environ["CONFIG_MISSING"], "1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- load backend configuration only from ENV_FILE and mark missing configs
- report configuration status via /health and propagate Excel path errors
- raise FileNotFoundError when complaints Excel path is unset or invalid
- ignore .env files in version control and add tests for new behavior

## Testing
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_b_68b7675c3e60832f90cec9090403fa6f