### PR TITLE
feat: allow switching guideline method

### DIFF
--- a/frontend/src/__tests__/GuidelineEditorModal.test.jsx
+++ b/frontend/src/__tests__/GuidelineEditorModal.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import GuidelineEditorModal from '../components/GuidelineEditorModal'
 import { API_BASE } from '../api'
 
@@ -11,13 +12,33 @@ test('loads guideline content on open', async () => {
   vi.spyOn(global, 'fetch').mockResolvedValueOnce({
     json: () => Promise.resolve(mockData)
   })
-  render(<GuidelineEditorModal open onClose={() => {}} method="8D" />)
+  render(<GuidelineEditorModal open onClose={() => {}} initialMethod="8D" />)
   await waitFor(() =>
     expect(global.fetch).toHaveBeenCalledWith(`${API_BASE}/guide/8D`)
   )
   await waitFor(() =>
-    expect(screen.getByRole('textbox')).toHaveValue(
-      JSON.stringify(mockData, null, 2)
-    )
+    expect(
+      screen.getByRole('textbox', { name: 'guideline-content' })
+    ).toHaveValue(JSON.stringify(mockData, null, 2))
+  )
+})
+
+test('allows switching between guideline methods', async () => {
+  const responses = [
+    { json: () => Promise.resolve({ step: '8D data' }) },
+    { json: () => Promise.resolve({ step: 'A3 data' }) }
+  ]
+  vi.spyOn(global, 'fetch').mockImplementation(() =>
+    Promise.resolve(responses.shift())
+  )
+  const user = userEvent.setup()
+  render(<GuidelineEditorModal open onClose={() => {}} />)
+  await waitFor(() =>
+    expect(global.fetch).toHaveBeenCalledWith(`${API_BASE}/guide/8D`)
+  )
+  await user.click(screen.getByLabelText(/method/i))
+  await user.click(screen.getByRole('option', { name: 'A3' }))
+  await waitFor(() =>
+    expect(global.fetch).toHaveBeenCalledWith(`${API_BASE}/guide/A3`)
   )
 })

--- a/frontend/src/components/GuidelineEditorModal.jsx
+++ b/frontend/src/components/GuidelineEditorModal.jsx
@@ -1,9 +1,18 @@
 import React, { useEffect, useState } from 'react'
-import { Modal, Box, Typography, IconButton, TextField, Button } from '@mui/material'
+import {
+  Modal,
+  Box,
+  Typography,
+  IconButton,
+  TextField,
+  Button,
+  MenuItem
+} from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 import { API_BASE } from '../api'
 
-function GuidelineEditorModal({ open, onClose, method = '8D' }) {
+function GuidelineEditorModal({ open, onClose, initialMethod = '8D' }) {
+  const [method, setMethod] = useState(initialMethod)
   const [content, setContent] = useState('')
 
   useEffect(() => {
@@ -52,8 +61,21 @@ function GuidelineEditorModal({ open, onClose, method = '8D' }) {
           <CloseIcon />
         </IconButton>
         <Typography id="guideline-editor-title" variant="h6" sx={{ mb: 2 }}>
-          {method} Guideline
+          Guideline Editor
         </Typography>
+        <TextField
+          select
+          label="Method"
+          value={method}
+          onChange={(e) => setMethod(e.target.value)}
+          sx={{ mb: 2 }}
+        >
+          {['5N1K', '8D', 'A3', 'DMAIC', 'Ishikawa'].map((m) => (
+            <MenuItem key={m} value={m}>
+              {m}
+            </MenuItem>
+          ))}
+        </TextField>
         <TextField
           multiline
           fullWidth
@@ -61,6 +83,7 @@ function GuidelineEditorModal({ open, onClose, method = '8D' }) {
           maxRows={25}
           value={content}
           onChange={(e) => setContent(e.target.value)}
+          inputProps={{ 'aria-label': 'guideline-content' }}
           sx={{ mb: 2, flexGrow: 1, overflowY: 'auto' }}
         />
         <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 1 }}>


### PR DESCRIPTION
## Summary
- add dropdown to GuidelineEditorModal for selecting 5N1K, 8D, A3, DMAIC, or Ishikawa guides
- update tests to cover guideline method switching

## Testing
- `npm test -- --run src/__tests__/GuidelineEditorModal.test.jsx --silent`
- `python -m unittest discover`
- `npm test --silent` *(fails: Unable to find an element with text...)*

------
https://chatgpt.com/codex/tasks/task_b_68b788301518832fb3bd43655d4be6bd