### PR TITLE
Fix NSIS installer language configuration

### DIFF
--- a/electron/build/installer.nsh
+++ b/electron/build/installer.nsh
@@ -8,7 +8,6 @@ Var ComplaintsControl
 
 Page custom GetInputs
 !insertmacro MUI_PAGE_INSTFILES
-!insertmacro MUI_LANGUAGE "Turkish"
 
 Function GetInputs
     nsDialogs::Create 1018

--- a/electron/package.json
+++ b/electron/package.json
@@ -34,7 +34,8 @@
     "nsis": {
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
-      "include": "build/installer.nsh"
+      "include": "build/installer.nsh",
+      "language": "tr_TR"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Avoid NSIS warning by removing manual language macro
- Configure Turkish installer language via package.json

## Testing
- `python -m unittest discover`
- `npm run dist` *(fails: wine is required)*

------
https://chatgpt.com/codex/tasks/task_b_68b7f901b940832f88a4db811c6b14b0