### PR TITLE
fix: correct NSIS language code

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -35,7 +35,7 @@
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
       "include": "build/installer.nsh",
-      "language": "tr_TR"
+      "language": "1055"
     }
   }
 }


### PR DESCRIPTION
## Summary
- fix NSIS language option for Windows installer to use numeric code 1055

## Testing
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_b_68b7fbf25e74832f92266240416cb1d0