### PR TITLE
Remove redundant NSIS language macro

### DIFF
--- a/electron/build/installer.nsh
+++ b/electron/build/installer.nsh
@@ -9,7 +9,6 @@ Var ComplaintsControl
 !insertmacro MUI_PAGE_DIRECTORY
 Page custom InputPageCreate InputPageLeave
 !insertmacro MUI_PAGE_INSTFILES
-!insertmacro MUI_LANGUAGE "Turkish"
 
 Function InputPageCreate
   nsDialogs::Create 1018


### PR DESCRIPTION
## Summary
- Drop `!insertmacro MUI_LANGUAGE` from custom NSIS script; electron-builder's `language` option now handles language selection, preventing `MUI_UNPAGE_* inserted after MUI_LANGUAGE` warning that aborted builds

## Testing
- `python -m unittest discover`
- `npm run dist` *(fails: app-builder process failed, environment limitation)*

------
https://chatgpt.com/codex/tasks/task_b_68b826f97464832f8f1c3b8caa7b8634