### PR TITLE
fix: load UI from asar path

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -32,8 +32,8 @@ function createWindow() {
     },
   });
 
-  const indexPath = path.join(process.resourcesPath, 'ui', 'index.html');
-  mainWindow.loadURL(`file://${indexPath}`);
+  const indexPath = path.join(__dirname, 'ui', 'index.html');
+  mainWindow.loadFile(indexPath);
   mainWindow.once('ready-to-show', () => {
     mainWindow.show();
   });


### PR DESCRIPTION
## Summary
- load packaged UI using `__dirname` to avoid blank window

## Testing
- `python -m unittest discover`
- `pre-commit run --files electron/main.js`


------
https://chatgpt.com/codex/tasks/task_b_68b82e10cdd4832fade384795f38004d