### PR TITLE
Handle modal fetch failures and disable Electron fullscreen

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -26,6 +26,7 @@ function createWindow() {
     width: 800,
     height: 600,
     show: false,
+    fullscreenable: false,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,

--- a/frontend/src/__tests__/GuidelineEditorModal.test.jsx
+++ b/frontend/src/__tests__/GuidelineEditorModal.test.jsx
@@ -42,3 +42,9 @@ test('allows switching between guideline methods', async () => {
     expect(global.fetch).toHaveBeenCalledWith(`${API_BASE}/guide/A3`)
   )
 })
+
+test('shows error on fetch failure', async () => {
+  vi.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('boom'))
+  render(<GuidelineEditorModal open onClose={() => {}} />)
+  await waitFor(() => expect(screen.getByText('boom')).toBeInTheDocument())
+})

--- a/frontend/src/__tests__/PromptEditorModal.test.jsx
+++ b/frontend/src/__tests__/PromptEditorModal.test.jsx
@@ -17,3 +17,9 @@ test('loads prompt text on open', async () => {
   )
   await waitFor(() => expect(screen.getByRole('textbox')).toHaveValue(text))
 })
+
+test('shows error on fetch failure', async () => {
+  vi.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('oops'))
+  render(<PromptEditorModal open onClose={() => {}} />)
+  await waitFor(() => expect(screen.getByText('oops')).toBeInTheDocument())
+})

--- a/frontend/src/components/GuidelineEditorModal.jsx
+++ b/frontend/src/components/GuidelineEditorModal.jsx
@@ -6,7 +6,8 @@ import {
   IconButton,
   TextField,
   Button,
-  MenuItem
+  MenuItem,
+  Alert
 } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 import { API_BASE } from '../api'
@@ -14,12 +15,15 @@ import { API_BASE } from '../api'
 function GuidelineEditorModal({ open, onClose, initialMethod = '8D' }) {
   const [method, setMethod] = useState(initialMethod)
   const [content, setContent] = useState('')
+  const [error, setError] = useState('')
 
   useEffect(() => {
     if (open) {
+      setError('')
       fetch(`${API_BASE}/guide/${method}`)
         .then((res) => res.json())
         .then((data) => setContent(JSON.stringify(data, null, 2)))
+        .catch((err) => setError(err.message))
     }
   }, [open, method])
 
@@ -36,6 +40,7 @@ function GuidelineEditorModal({ open, onClose, initialMethod = '8D' }) {
       .then(() => fetch(`${API_BASE}/guide/${method}`))
       .then((res) => res.json())
       .then((data) => setContent(JSON.stringify(data, null, 2)))
+      .catch((err) => setError(err.message))
   }
 
   return (
@@ -63,6 +68,11 @@ function GuidelineEditorModal({ open, onClose, initialMethod = '8D' }) {
         <Typography id="guideline-editor-title" variant="h6" sx={{ mb: 2 }}>
           Guideline Editor
         </Typography>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
         <TextField
           select
           label="Method"

--- a/frontend/src/components/PromptEditorModal.jsx
+++ b/frontend/src/components/PromptEditorModal.jsx
@@ -1,16 +1,27 @@
 import React, { useEffect, useState } from 'react'
-import { Modal, Box, Typography, IconButton, TextField, Button } from '@mui/material'
+import {
+  Modal,
+  Box,
+  Typography,
+  IconButton,
+  TextField,
+  Button,
+  Alert
+} from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 import { API_BASE } from '../api'
 
 function PromptEditorModal({ open, onClose, method = 'A3' }) {
   const [content, setContent] = useState('')
+  const [error, setError] = useState('')
 
   useEffect(() => {
     if (open) {
+      setError('')
       fetch(`${API_BASE}/prompt/${method}`)
         .then((res) => res.json())
         .then((data) => setContent(data.text))
+        .catch((err) => setError(err.message))
     }
   }, [open, method])
 
@@ -27,6 +38,7 @@ function PromptEditorModal({ open, onClose, method = 'A3' }) {
       .then(() => fetch(`${API_BASE}/prompt/${method}`))
       .then((res) => res.json())
       .then((data) => setContent(data.text))
+      .catch((err) => setError(err.message))
   }
 
   return (
@@ -54,6 +66,11 @@ function PromptEditorModal({ open, onClose, method = 'A3' }) {
         <Typography id="prompt-editor-title" variant="h6" sx={{ mb: 2 }}>
           {method} Prompt
         </Typography>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
         <TextField
           multiline
           fullWidth


### PR DESCRIPTION
## Summary
- display error alerts if guideline or prompt fetch fails
- prevent fullscreen to keep window controls in Electron app
- test coverage for guideline and prompt fetch errors

## Testing
- `npx vitest run src/__tests__/GuidelineEditorModal.test.jsx src/__tests__/PromptEditorModal.test.jsx`
- `npm test` *(fails: src/__tests__/AnalysisForm.test.jsx > fetches filtered claims)*
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_b_68b834365d34832f8b943992a7587ec3