### PR TITLE
Use environment directories for prompts and guidelines

### DIFF
--- a/Review/__init__.py
+++ b/Review/__init__.py
@@ -22,8 +22,15 @@ class Review:
         self.logger = logging.getLogger(__name__)
 
         if template_path is None:
-            base_dir = Path(__file__).resolve().parents[1] / "Prompts"
-            template_path = base_dir / "Fixer_General_Prompt.md"
+            base_dir = os.environ.get("PROMPTS_DIR")
+            if not base_dir:
+                raise RuntimeError("PROMPTS_DIR missing")
+            primary = Path(base_dir) / "Fixer_General_Prompt.md"
+            if primary.exists():
+                template_path = primary
+            else:  # pragma: no cover - fallback only when missing
+                package_dir = Path(__file__).resolve().parents[1] / "Prompts"
+                template_path = package_dir / "Fixer_General_Prompt.md"
         with open(template_path, "r", encoding="utf-8") as file:
             self.template = file.read()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from unittest.mock import patch
 
@@ -6,6 +7,11 @@ import tempfile
 from pathlib import Path
 from ComplaintSearch import ComplaintStore
 from LLMAnalyzer import OpenAIError
+
+base_prompts = Path(__file__).resolve().parents[1] / "Prompts"
+base_guides = Path(__file__).resolve().parents[1] / "Guidelines"
+os.environ.setdefault("PROMPTS_DIR", str(base_prompts))
+os.environ.setdefault("GUIDELINES_DIR", str(base_guides))
 
 import api
 

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -2,6 +2,12 @@ import logging
 import os
 import unittest
 from unittest.mock import patch
+from pathlib import Path
+
+base_prompts = Path(__file__).resolve().parents[1] / "Prompts"
+base_guides = Path(__file__).resolve().parents[1] / "Guidelines"
+os.environ.setdefault("PROMPTS_DIR", str(base_prompts))
+os.environ.setdefault("GUIDELINES_DIR", str(base_guides))
 
 from api.logging_config import configure_logging
 

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -14,8 +14,13 @@ class ReportGeneratorTest(unittest.TestCase):
     """Tests for ReportGenerator.generate."""
 
     def setUp(self) -> None:
+        base_dir = Path(__file__).resolve().parents[1] / "Guidelines"
+        os.environ["GUIDELINES_DIR"] = str(base_dir)
         self.manager = GuideManager()
         self.generator = ReportGenerator(self.manager)
+
+    def tearDown(self) -> None:
+        del os.environ["GUIDELINES_DIR"]
 
     def test_generate_creates_files(self) -> None:
         analysis = {"Step1": {"response": "foo"}, "Step2": {"response": "bar"}}

--- a/tests/test_run_api.py
+++ b/tests/test_run_api.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import unittest
 from unittest.mock import patch
+from pathlib import Path
 
 
 class RunAPITest(unittest.TestCase):
@@ -10,11 +11,21 @@ class RunAPITest(unittest.TestCase):
 
     def test_main_with_env_file(self) -> None:
         """``main`` should load dotenv when ``ENV_FILE`` exists."""
+        base_prompts = Path(__file__).resolve().parents[1] / "Prompts"
+        base_guides = Path(__file__).resolve().parents[1] / "Guidelines"
         with tempfile.TemporaryDirectory() as tmpdir:
             env_path = os.path.join(tmpdir, ".env")
             with open(env_path, "w", encoding="utf-8") as fh:
                 fh.write("OPENAI_API_KEY=key")
-            with patch.dict(os.environ, {"ENV_FILE": env_path}, clear=True):
+            with patch.dict(
+                os.environ,
+                {
+                    "ENV_FILE": env_path,
+                    "PROMPTS_DIR": str(base_prompts),
+                    "GUIDELINES_DIR": str(base_guides),
+                },
+                clear=True,
+            ):
                 module = importlib.import_module("run_api")
                 with patch.object(module, "uvicorn") as mock_uvicorn, \
                         patch.object(module, "configure_logging") as mock_conf, \
@@ -29,7 +40,16 @@ class RunAPITest(unittest.TestCase):
 
     def test_main_without_env_file(self) -> None:
         """``main`` should not load dotenv when ``ENV_FILE`` is missing."""
-        with patch.dict(os.environ, {}, clear=True):
+        base_prompts = Path(__file__).resolve().parents[1] / "Prompts"
+        base_guides = Path(__file__).resolve().parents[1] / "Guidelines"
+        with patch.dict(
+            os.environ,
+            {
+                "PROMPTS_DIR": str(base_prompts),
+                "GUIDELINES_DIR": str(base_guides),
+            },
+            clear=True,
+        ):
             module = importlib.import_module("run_api")
             with patch.object(module, "uvicorn") as mock_uvicorn, \
                     patch.object(module, "configure_logging") as mock_conf, \


### PR DESCRIPTION
## Summary
- Load Review prompts from `PROMPTS_DIR` with fallback to packaged defaults
- Require `GUIDELINES_DIR` for GuideManager and fallback to package files when missing
- Add tests covering environment directory usage and update existing tests

## Testing
- `PROMPTS_DIR=$(pwd)/Prompts GUIDELINES_DIR=$(pwd)/Guidelines python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_68b87693e69c832f89ac3d7719d75979