### PR TITLE
Ensure review prompt is bundled with executable

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,6 @@ install_requires =
     starlette==0.36.3
     httpx==0.27.*
     uvicorn
+
+[options.package_data]
+Prompts = *.md, *.txt


### PR DESCRIPTION
## Summary
- Load default Review template from package resources when no custom path is provided
- Include prompt markdown files as package data for packaging tools

## Testing
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_b_68b87e6034b8832f9715560db4f9da50