### PR TITLE
Ensure bundled prompts package is importable

### DIFF
--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -10,11 +10,8 @@ class ReviewPromptTest(unittest.TestCase):
     """Tests for Review prompt loading from environment."""
 
     def setUp(self) -> None:
-        self.default_prompt = (
-            Path(__file__).resolve().parents[1]
-            / "Prompts"
-            / "Fixer_General_Prompt.md"
-        )
+        root = Path(__file__).resolve().parents[1]
+        self.default_prompt = root / "Prompts" / "Fixer_General_Prompt.md"
         with open(self.default_prompt, "r", encoding="utf-8") as f:
             self.default_content = f.read()
 


### PR DESCRIPTION
## Summary
- import the Prompts package and reference it with `importlib.resources.files` so bundled builds find prompt templates
- tidy Review prompt loader and simplify default test setup

## Testing
- `pre-commit run --files Review/__init__.py tests/test_review.py`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_68b880430064832f92e74ef997fd4684