### PR TITLE
Fallback to builtin review prompt

### DIFF
--- a/Review/__init__.py
+++ b/Review/__init__.py
@@ -9,6 +9,13 @@ from importlib import resources as pkg_resources
 import Prompts
 
 
+FALLBACK_PROMPT = (
+    "Review the following report for clarity and correctness.\n"
+    "Return the improved text only in {language}.\n\n"
+    "{initial_report_text}\n"
+)
+
+
 class ReviewLLMError(RuntimeError):
     """Raised when the review LLM cannot be used."""
 
@@ -43,8 +50,11 @@ class Review:
                     .read_text(encoding="utf-8")
                 )
                 self.template = resource
-            except (FileNotFoundError, ModuleNotFoundError) as exc:
-                raise ReviewLLMError("Prompt template not found") from exc
+            except (FileNotFoundError, ModuleNotFoundError):
+                self.logger.warning(
+                    "Prompt template not found; using built-in default"
+                )
+                self.template = FALLBACK_PROMPT
 
     def _query_llm(self, prompt: str) -> str:
         """Return the LLM response for the given prompt."""

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from Review import Review
 
@@ -35,6 +36,12 @@ class ReviewPromptTest(unittest.TestCase):
             review = Review()
             self.assertEqual(review.template, "CUSTOM")
         os.environ.pop("PROMPTS_DIR", None)
+
+    def test_builtin_prompt_used_when_resource_missing(self) -> None:
+        os.environ.pop("PROMPTS_DIR", None)
+        with patch("Review.pkg_resources.files", side_effect=FileNotFoundError):
+            review = Review()
+            self.assertEqual(review.template, self.default_content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- avoid crashing when bundled prompt is missing by falling back to a built-in template
- test Review behavior when packaged prompt resource is absent

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_68b8831c3fb0832f840c0064a804cf3f