### PR TITLE
Allow default guidelines without env variable

### DIFF
--- a/GuideManager/__init__.py
+++ b/GuideManager/__init__.py
@@ -31,14 +31,14 @@ class GuideManager:
     def _base_dir(self) -> Path:
         """Return the directory containing guideline files.
 
-        ``GUIDELINES_DIR`` must point to the user-configurable guidelines
-        directory. Packaged defaults are used only as a fallback when the
-        requested file does not exist in that location.
+        ``GUIDELINES_DIR`` can override the default location. When the
+        environment variable is absent, the packaged ``Guidelines`` directory
+        is used so the application functions with sensible defaults.
         """
         env_dir = os.environ.get("GUIDELINES_DIR")
-        if not env_dir:
-            raise RuntimeError("GUIDELINES_DIR missing")
-        return Path(env_dir)
+        if env_dir:
+            return Path(env_dir)
+        return Path(__file__).resolve().parents[1] / "Guidelines"
 
     def get_format(self, method: str) -> Dict[str, Any]:
         """Return the guide dictionary for the given method."""

--- a/tests/test_guide_manager.py
+++ b/tests/test_guide_manager.py
@@ -28,11 +28,15 @@ class GuideManagerTest(unittest.TestCase):
                 result = self.manager.get_format(method)
                 self.assertEqual(result, expected)
 
-    def test_missing_env_var_raises(self) -> None:
-        """``GUIDELINES_DIR`` must be set."""
-        del os.environ["GUIDELINES_DIR"]
-        with self.assertRaises(RuntimeError):
-            GuideManager().get_format("8D")
+    def test_env_var_optional(self) -> None:
+        """Manager should use packaged guides when ``GUIDELINES_DIR`` is unset."""
+        os.environ.pop("GUIDELINES_DIR", None)
+        manager = GuideManager()
+        expected_path = self.base_dir / "8D_Guide.json"
+        with open(expected_path, "r", encoding="utf-8") as f:
+            expected = json.load(f)
+        result = manager.get_format("8D")
+        self.assertEqual(result, expected)
 
     def test_fallback_to_package_files(self) -> None:
         """Missing files in ``GUIDELINES_DIR`` fall back to packaged ones."""


### PR DESCRIPTION
## Summary
- fallback to packaged `Guidelines` directory when `GUIDELINES_DIR` is unset
- cover optional env var behavior in guide manager tests

## Testing
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_b_68b889713574832fb048159693cb2054