### PR TITLE
Improve bundled backend prompt handling

### DIFF
--- a/Review/__init__.py
+++ b/Review/__init__.py
@@ -37,22 +37,35 @@ class Review:
             if base_dir:
                 primary = Path(base_dir) / "Fixer_General_Prompt.md"
                 if primary.exists():
-                    template_path = primary
+                    template_path = str(primary)
 
         if template_path is not None:
             with open(template_path, "r", encoding="utf-8") as file:
                 self.template = file.read()
-        else:  # pragma: no cover - executed only when file is bundled
+        else:
+            # PyInstaller bundle içinde dosya arama
             try:
-                resource = (
-                    pkg_resources.files(Prompts)
-                    .joinpath("Fixer_General_Prompt.md")
-                    .read_text(encoding="utf-8")
-                )
-                self.template = resource
+                import sys
+
+                if getattr(sys, "frozen", False):
+                    # Bundle içindeyse
+                    bundle_dir = sys._MEIPASS
+                    prompt_file = os.path.join(
+                        bundle_dir, "Prompts", "Fixer_General_Prompt.md"
+                    )
+                    with open(prompt_file, "r", encoding="utf-8") as file:
+                        self.template = file.read()
+                else:
+                    # Normal Python çalıştırılıyorsa pkg_resources kullan
+                    resource = (
+                        pkg_resources.files(Prompts)
+                        .joinpath("Fixer_General_Prompt.md")
+                        .read_text(encoding="utf-8")
+                    )
+                    self.template = resource
             except (FileNotFoundError, ModuleNotFoundError):
                 self.logger.warning(
-                    "Prompt template not found; using built-in default"
+                    "Prompt template not found; using built-in default",
                 )
                 self.template = FALLBACK_PROMPT
 

--- a/backend.spec
+++ b/backend.spec
@@ -1,0 +1,45 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+
+a = Analysis(
+    ['run_api.py'],
+    pathex=[],
+    binaries=[],
+    datas=[
+        ('Prompts', 'Prompts'),
+        ('Guidelines', 'Guidelines'),
+    ],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name='backend',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=None,
+)

--- a/electron/main.js
+++ b/electron/main.js
@@ -51,9 +51,26 @@ app.whenReady().then(() => {
 
   const backendExe = path.join(process.resourcesPath, 'backend', 'backend.exe');
   backendProcess = spawn(backendExe, [], {
-    env: { ...process.env, ENV_FILE: envPath },
-    stdio: 'ignore',
+    env: {
+      ...process.env,
+      ENV_FILE: envPath,
+      PROMPTS_DIR: path.join(appDataRoot, 'prompts'),
+    },
+    stdio: ['ignore', 'pipe', 'pipe'], // Hata loglarını görmek için
     windowsHide: true,
+  });
+
+  // Hata loglarını yakala
+  backendProcess.stderr.on('data', (data) => {
+    console.error('Backend error:', data.toString());
+  });
+
+  backendProcess.stdout.on('data', (data) => {
+    console.log('Backend output:', data.toString());
+  });
+
+  backendProcess.on('exit', (code) => {
+    console.log('Backend exited with code:', code);
   });
 
   ipcMain.handle('guidelines:open', () => shell.openPath(userGuidelines));


### PR DESCRIPTION
## Summary
- Look for prompt templates in `PROMPTS_DIR` and bundled resources when running the backend
- Bundle `Prompts` and `Guidelines` folders in PyInstaller build
- Propagate `PROMPTS_DIR` to backend from Electron and log backend output

## Testing
- `python -m unittest discover`
- `pyinstaller backend.spec`
- `npm run prep` *(fails: cp: no such file or directory: ../frontend/dist/*)*
- `npm run dist` *(fails: ERR_ELECTRON_BUILDER_CANNOT_EXECUTE)*
- `ENV_FILE="$HOME/.env" PROMPTS_DIR="$HOME/prompts" ./backend` *(fails: Environment file missing; set ENV_FILE to a valid .env path)*

------
https://chatgpt.com/codex/tasks/task_b_68b890f0c728832f8237ad81de645723