### PR TITLE
Handle streams without isatty

### DIFF
--- a/api/logging_config.py
+++ b/api/logging_config.py
@@ -4,8 +4,19 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
+from typing import TextIO
 
 __all__ = ["configure_logging"]
+
+
+def _default_stream() -> TextIO:
+    """Return a sensible stream for logging based on TTY availability."""
+    if hasattr(sys.stdout, "isatty") and sys.stdout.isatty():
+        return sys.stdout
+    if hasattr(sys.stderr, "isatty") and sys.stderr.isatty():
+        return sys.stderr
+    return sys.stderr
 
 
 def configure_logging() -> None:
@@ -16,5 +27,5 @@ def configure_logging() -> None:
     if not has_real:
         level_name = os.getenv("LOG_LEVEL", "INFO").upper()
         level = getattr(logging, level_name, logging.INFO)
-        logging.basicConfig(level=level)
+        logging.basicConfig(level=level, stream=_default_stream())
 

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from pathlib import Path
 
 base_prompts = Path(__file__).resolve().parents[1] / "Prompts"
@@ -28,25 +28,46 @@ class LoggingConfigTest(unittest.TestCase):
             self.root.addHandler(handler)
 
     def test_basic_config_called_no_handlers(self) -> None:
-        with patch("logging.basicConfig") as mock_basic:
+        with patch("api.logging_config.sys.stdout", new=MagicMock()) as mock_stdout, \
+             patch("api.logging_config.sys.stderr", new=MagicMock()) as mock_stderr, \
+             patch("logging.basicConfig") as mock_basic:
+            mock_stdout.isatty.return_value = False
+            mock_stderr.isatty.return_value = False
             configure_logging()
-            mock_basic.assert_called_once_with(level=logging.INFO)
+            mock_basic.assert_called_once_with(level=logging.INFO, stream=mock_stderr)
 
     def test_level_from_env(self) -> None:
-        with patch("logging.basicConfig") as mock_basic, \
+        with patch("api.logging_config.sys.stdout", new=MagicMock()) as mock_stdout, \
+             patch("api.logging_config.sys.stderr", new=MagicMock()) as mock_stderr, \
+             patch("logging.basicConfig") as mock_basic, \
              patch.dict(os.environ, {"LOG_LEVEL": "DEBUG"}):
+            mock_stdout.isatty.return_value = False
+            mock_stderr.isatty.return_value = False
             configure_logging()
-            mock_basic.assert_called_once_with(level=logging.DEBUG)
+            mock_basic.assert_called_once_with(level=logging.DEBUG, stream=mock_stderr)
 
     def test_no_config_when_handlers_exist(self) -> None:
         handler = logging.NullHandler()
         self.root.addHandler(handler)
         try:
-            with patch("logging.basicConfig") as mock_basic:
+            with patch("api.logging_config.sys.stdout", new=MagicMock()) as mock_stdout, \
+                 patch("api.logging_config.sys.stderr", new=MagicMock()) as mock_stderr, \
+                 patch("logging.basicConfig") as mock_basic:
+                mock_stdout.isatty.return_value = False
+                mock_stderr.isatty.return_value = False
                 configure_logging()
                 mock_basic.assert_not_called()
         finally:
             self.root.removeHandler(handler)
+
+    def test_prefers_stdout_when_tty(self) -> None:
+        with patch("api.logging_config.sys.stdout", new=MagicMock()) as mock_stdout, \
+             patch("api.logging_config.sys.stderr", new=MagicMock()) as mock_stderr, \
+             patch("logging.basicConfig") as mock_basic:
+            mock_stdout.isatty.return_value = True
+            mock_stderr.isatty.return_value = True
+            configure_logging()
+            mock_basic.assert_called_once_with(level=logging.INFO, stream=mock_stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Safely choose logging stream when stdout/stderr may not provide `isatty`
- Add tests covering stream selection logic in logging configuration

## Testing
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_b_68b89f69b998832f85961deb9c990b7f