### PR TITLE
Handle missing stdio in PyInstaller API runner

### DIFF
--- a/run_api.py
+++ b/run_api.py
@@ -28,7 +28,26 @@ def main() -> None:
     """Start the API server."""
     configure_logging()
     _load_env()
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+    # PyInstaller ile paketlenmiş uygulamalar için uvicorn konfigürasyonu
+    import sys
+
+    # stdout/stderr'ın None olması durumunda dummy objeler oluştur
+    if sys.stdout is None:
+        import io
+        sys.stdout = io.StringIO()
+    if sys.stderr is None:
+        import io
+        sys.stderr = io.StringIO()
+
+    # Uvicorn'u logging sorunlarını önleyecek şekilde başlat
+    uvicorn.run(
+        app,
+        host="0.0.0.0",
+        port=8000,
+        log_config=None,  # Uvicorn'un kendi logging config'ini devre dışı bırak
+        access_log=False
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_run_api.py
+++ b/tests/test_run_api.py
@@ -34,7 +34,11 @@ class RunAPITest(unittest.TestCase):
                     mock_conf.assert_called_once()
                     mock_load.assert_called_once_with(env_path)
                     mock_uvicorn.run.assert_called_once_with(
-                        module.app, host="0.0.0.0", port=8000
+                        module.app,
+                        host="0.0.0.0",
+                        port=8000,
+                        log_config=None,
+                        access_log=False,
                     )
                     self.assertEqual(os.environ["CONFIG_MISSING"], "0")
 
@@ -58,9 +62,43 @@ class RunAPITest(unittest.TestCase):
                 mock_conf.assert_called_once()
                 mock_load.assert_not_called()
                 mock_uvicorn.run.assert_called_once_with(
-                    module.app, host="0.0.0.0", port=8000
+                    module.app,
+                    host="0.0.0.0",
+                    port=8000,
+                    log_config=None,
+                    access_log=False,
                 )
                 self.assertEqual(os.environ["CONFIG_MISSING"], "1")
+
+    def test_main_replaces_missing_stdio(self) -> None:
+        """``main`` should create stdio streams when missing."""
+        base_prompts = Path(__file__).resolve().parents[1] / "Prompts"
+        base_guides = Path(__file__).resolve().parents[1] / "Guidelines"
+        with patch.dict(
+            os.environ,
+            {
+                "PROMPTS_DIR": str(base_prompts),
+                "GUIDELINES_DIR": str(base_guides),
+            },
+            clear=True,
+        ):
+            module = importlib.import_module("run_api")
+            import sys
+            with patch.object(module, "uvicorn") as mock_uvicorn, \
+                    patch.object(module, "configure_logging"), \
+                    patch.object(module, "load_dotenv"), \
+                    patch.object(sys, "stdout", None), \
+                    patch.object(sys, "stderr", None):
+                module.main()
+                self.assertIsNotNone(sys.stdout)
+                self.assertIsNotNone(sys.stderr)
+                mock_uvicorn.run.assert_called_once_with(
+                    module.app,
+                    host="0.0.0.0",
+                    port=8000,
+                    log_config=None,
+                    access_log=False,
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure `run_api` creates dummy `stdout`/`stderr` when missing for PyInstaller builds
- disable uvicorn's internal logging config and access log to avoid conflicts
- test the new stdio handling and updated uvicorn parameters

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_68b8a2e81264832fa534bd6cad753345