### PR TITLE
Enable prompt method selection and improve report error messaging

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -133,10 +133,7 @@ def report(body: ReportBody) -> Dict[str, str]:
         )
     except Exception as exc:  # pragma: no cover - unexpected failure
         logger.exception("Report generation failed")
-        raise HTTPException(
-            status_code=500,
-            detail="Report generation failed",
-        ) from exc
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
     result = {
         "pdf": f"/reports/{Path(paths['pdf']).name}",
         "excel": f"/reports/{Path(paths['excel']).name}",

--- a/frontend/src/__tests__/PromptEditorModal.test.jsx
+++ b/frontend/src/__tests__/PromptEditorModal.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import PromptEditorModal from '../components/PromptEditorModal'
 import { API_BASE } from '../api'
 
@@ -6,16 +7,23 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-test('loads prompt text on open', async () => {
-  const text = 'Example prompt'
-  vi.spyOn(global, 'fetch').mockResolvedValueOnce({
-    json: () => Promise.resolve({ text })
-  })
-  render(<PromptEditorModal open onClose={() => {}} method="A3" />)
+test('loads prompt text and updates when method changes', async () => {
+  const a3Text = 'Example A3'
+  const d8Text = 'Example 8D'
+  vi.spyOn(global, 'fetch')
+    .mockResolvedValueOnce({ json: () => Promise.resolve({ text: a3Text }) })
+    .mockResolvedValueOnce({ json: () => Promise.resolve({ text: d8Text }) })
+  render(<PromptEditorModal open onClose={() => {}} initialMethod="A3" />)
   await waitFor(() =>
     expect(global.fetch).toHaveBeenCalledWith(`${API_BASE}/prompt/A3`)
   )
-  await waitFor(() => expect(screen.getByRole('textbox')).toHaveValue(text))
+  await waitFor(() => expect(screen.getByRole('textbox')).toHaveValue(a3Text))
+  await userEvent.click(screen.getByLabelText('Method'))
+  await userEvent.click(await screen.findByRole('option', { name: '8D' }))
+  await waitFor(() =>
+    expect(global.fetch).toHaveBeenCalledWith(`${API_BASE}/prompt/8D`)
+  )
+  await waitFor(() => expect(screen.getByRole('textbox')).toHaveValue(d8Text))
 })
 
 test('shows error on fetch failure', async () => {

--- a/frontend/src/components/PromptEditorModal.jsx
+++ b/frontend/src/components/PromptEditorModal.jsx
@@ -6,12 +6,14 @@ import {
   IconButton,
   TextField,
   Button,
-  Alert
+  Alert,
+  MenuItem
 } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 import { API_BASE } from '../api'
 
-function PromptEditorModal({ open, onClose, method = 'A3' }) {
+function PromptEditorModal({ open, onClose, initialMethod = 'A3' }) {
+  const [method, setMethod] = useState(initialMethod)
   const [content, setContent] = useState('')
   const [error, setError] = useState('')
 
@@ -64,8 +66,21 @@ function PromptEditorModal({ open, onClose, method = 'A3' }) {
           <CloseIcon />
         </IconButton>
         <Typography id="prompt-editor-title" variant="h6" sx={{ mb: 2 }}>
-          {method} Prompt
+          Prompt Editor
         </Typography>
+        <TextField
+          select
+          label="Method"
+          value={method}
+          onChange={(e) => setMethod(e.target.value)}
+          sx={{ mb: 2 }}
+        >
+          {['5N1K', '8D', 'A3', 'DMAIC', 'Ishikawa'].map((m) => (
+            <MenuItem key={m} value={m}>
+              {m}
+            </MenuItem>
+          ))}
+        </TextField>
         {error && (
           <Alert severity="error" sx={{ mb: 2 }}>
             {error}


### PR DESCRIPTION
## Summary
- expose underlying exception details when report generation fails
- allow editing prompts for multiple methods via dropdown
- add tests for prompt method selection

## Testing
- `pre-commit run --files api/__init__.py tests/test_api.py frontend/src/components/PromptEditorModal.jsx frontend/src/__tests__/PromptEditorModal.test.jsx`
- `python -m unittest discover`
- `npm test` *(fails: claims fail, server error)*
- `npm test src/__tests__/PromptEditorModal.test.jsx`


------
https://chatgpt.com/codex/tasks/task_b_68b8c3a8d788832f96a00a4abe3898be