### PR TITLE
Handle JSON error details

### DIFF
--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -384,6 +384,33 @@ test('hides report links when report request fails', async () => {
   expect(screen.queryByTestId('pdf-link')).toBeNull()
 })
 
+test('shows detail message from JSON error response', async () => {
+  fetch
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ fields: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ analysisText: 'a' }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ result: 'r' }) })
+    .mockResolvedValueOnce({
+      ok: false,
+      text: async () => JSON.stringify({ detail: 'Report generation failed' })
+    })
+
+  render(<AnalysisForm initialMethod="8D" />)
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3))
+
+  fireEvent.change(screen.getByLabelText('Şikayet (Complaint)'), {
+    target: { value: 'c' }
+  })
+  fireEvent.click(screen.getByRole('button', { name: 'ANALİZ ET' }))
+
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(7))
+  expect(
+    await screen.findByText('Report generation failed')
+  ).toBeInTheDocument()
+})
+
 test('shows alert when analyze request rejects', async () => {
   fetch
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -169,6 +169,16 @@ function AnalysisForm({
     fetchOptions('subject', setSubjectOptions);
     fetchOptions('part_code', setPartCodeOptions);
   }, []);
+
+  const extractError = async (res) => {
+    const text = await res.text();
+    try {
+      const data = JSON.parse(text);
+      return data.detail || data.message || text;
+    } catch {
+      return text;
+    }
+  };
   const handleAnalyze = async () => {
     setError('');
     setLoading(true);
@@ -184,7 +194,7 @@ function AnalysisForm({
     try {
       const guideRes = await fetch(`${API_BASE}/guide/${method}`);
       if (!guideRes.ok) {
-        setError(await guideRes.text());
+        setError(await extractError(guideRes));
         return;
       }
       const guideline = await guideRes.json();
@@ -195,7 +205,7 @@ function AnalysisForm({
         body: JSON.stringify({ details, guideline, directives, language })
       });
       if (!analyzeRes.ok) {
-        setError(await analyzeRes.text());
+        setError(await extractError(analyzeRes));
         return;
       }
       const analysis = await analyzeRes.json();
@@ -221,7 +231,7 @@ function AnalysisForm({
         })
       });
       if (!reviewRes.ok) {
-        setError(await reviewRes.text());
+        setError(await extractError(reviewRes));
         return;
       }
       const reviewData = await reviewRes.json();
@@ -242,8 +252,7 @@ function AnalysisForm({
       });
 
       if (!reportRes.ok) {
-        const errorText = await reportRes.text();
-        setError(errorText);
+        setError(await extractError(reportRes));
         setReportPaths(null);
         return;
       } else {
@@ -309,7 +318,7 @@ function AnalysisForm({
       setLoading(true);
       const res = await fetch(`${API_BASE}/scan_8d`, { method: 'POST' });
       if (!res.ok) {
-        setError(await res.text());
+        setError(await extractError(res));
       }
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- Parse error responses to surface only `detail` or `message` fields in AnalysisForm
- Test that JSON error messages are displayed without surrounding JSON

## Testing
- `python -m unittest discover`
- `npm test --prefix frontend -- --run` *(fails: 5 tests failed)*

------
https://chatgpt.com/codex/tasks/task_b_68b8cf0a46c4832f8759e4dd5b8c095b