### PR TITLE
feat: persist env config via API

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -14,6 +14,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
+from dotenv import set_key
 
 from GuideManager import GuideManager
 from LLMAnalyzer import LLMAnalyzer
@@ -40,6 +41,27 @@ app.mount("/reports", StaticFiles(directory=str(REPORT_DIR)), name="reports")
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Environment configuration
+
+
+class SetupBody(BaseModel):
+    apiKey: str
+    excelPath: str
+
+
+@app.post("/setup")
+def setup(body: SetupBody) -> Dict[str, str]:
+    """Persist configuration values to the ``.env`` file."""
+    env_file = os.environ.get("ENV_FILE", ".env")
+    env_path = Path(env_file)
+    env_path.touch(exist_ok=True)
+    set_key(str(env_path), "OPENAI_API_KEY", body.apiKey)
+    set_key(str(env_path), "COMPLAINTS_XLSX_PATH", body.excelPath)
+    return {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
 # Map common query aliases to Excel header names
 ALIAS_TO_HEADER = {
     normalize_text("customer"): "Müşteri Adı",

--- a/frontend/src/__tests__/SettingsModal.test.jsx
+++ b/frontend/src/__tests__/SettingsModal.test.jsx
@@ -27,4 +27,20 @@ test('posts settings and closes', async () => {
     )
   )
   await waitFor(() => expect(onClose).toHaveBeenCalled())
+  expect(await screen.findByText('Ayarlar kaydedildi')).toBeInTheDocument()
+})
+
+test('shows error on failure', async () => {
+  const onClose = vi.fn()
+  vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network'))
+  render(<SettingsModal open onClose={onClose} />)
+  fireEvent.change(screen.getByLabelText(/openai api key/i), {
+    target: { value: 'sk-test' }
+  })
+  const file = new File(['data'], 'test.xlsx')
+  Object.defineProperty(file, 'path', { value: '/path/test.xlsx' })
+  fireEvent.change(screen.getByTestId('excel-input'), { target: { files: [file] } })
+  fireEvent.click(screen.getByText('Kaydet'))
+  await screen.findByText('Ayarlar kaydedilemedi')
+  expect(onClose).not.toHaveBeenCalled()
 })

--- a/frontend/src/components/SettingsModal.jsx
+++ b/frontend/src/components/SettingsModal.jsx
@@ -13,7 +13,7 @@ import { API_BASE } from '../api'
 function SettingsModal({ open, onClose }) {
   const [apiKey, setApiKey] = useState('')
   const [excelPath, setExcelPath] = useState('')
-  const [snackOpen, setSnackOpen] = useState(false)
+  const [snack, setSnack] = useState({ open: false, message: '', severity: 'success' })
 
   const handleFileChange = (e) => {
     const file = e.target.files?.[0]
@@ -23,14 +23,22 @@ function SettingsModal({ open, onClose }) {
   }
 
   const handleSave = async () => {
-    if (!apiKey.startsWith('sk-') || !excelPath) return
-    await fetch(`${API_BASE}/setup`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ apiKey, excelPath })
-    })
-    setSnackOpen(true)
-    onClose()
+    if (!apiKey.startsWith('sk-') || !excelPath) {
+      setSnack({ open: true, message: 'Geçersiz bilgi', severity: 'error' })
+      return
+    }
+    try {
+      const res = await fetch(`${API_BASE}/setup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ apiKey, excelPath })
+      })
+      if (!res.ok) throw new Error('failed')
+      setSnack({ open: true, message: 'Ayarlar kaydedildi', severity: 'success' })
+      onClose()
+    } catch {
+      setSnack({ open: true, message: 'Ayarlar kaydedilemedi', severity: 'error' })
+    }
   }
 
   return (
@@ -68,12 +76,12 @@ function SettingsModal({ open, onClose }) {
         </DialogActions>
       </Dialog>
       <Snackbar
-        open={snackOpen}
+        open={snack.open}
         autoHideDuration={3000}
-        onClose={() => setSnackOpen(false)}
+        onClose={() => setSnack((s) => ({ ...s, open: false }))}
       >
-        <Alert severity="success" sx={{ width: '100%' }}>
-          Ayarlar kaydedildi
+        <Alert severity={snack.severity} sx={{ width: '100%' }}>
+          {snack.message}
         </Alert>
       </Snackbar>
     </>

--- a/tests/test_setup_endpoint.py
+++ b/tests/test_setup_endpoint.py
@@ -1,0 +1,37 @@
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from fastapi.testclient import TestClient
+from dotenv import dotenv_values
+
+from api import app
+
+
+class SetupEndpointTest(unittest.TestCase):
+    """Tests for the /setup endpoint."""
+
+    def setUp(self) -> None:
+        self.tmpdir = TemporaryDirectory()
+        self.env_path = Path(self.tmpdir.name) / ".env"
+        os.environ["ENV_FILE"] = str(self.env_path)
+        self.client = TestClient(app)
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+        os.environ.pop("ENV_FILE", None)
+
+    def test_setup_writes_env_file(self) -> None:
+        response = self.client.post(
+            "/setup",
+            json={"apiKey": "sk-test", "excelPath": "/tmp/test.xlsx"},
+        )
+        self.assertEqual(response.status_code, 200)
+        data = dotenv_values(self.env_path)
+        self.assertEqual(data.get("OPENAI_API_KEY"), "sk-test")
+        self.assertEqual(data.get("COMPLAINTS_XLSX_PATH"), "/tmp/test.xlsx")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `/setup` endpoint to persist API key and Excel path
- show success or error feedback in SettingsModal
- cover new endpoint with unit test

## Testing
- `python -m unittest discover`
- `pre-commit run --files api/__init__.py tests/test_setup_endpoint.py`
- `npm test` *(fails: Unable to find an element with the text: /Fetched 1 claims/)*

------
https://chatgpt.com/codex/tasks/task_b_68b9a6f7d74c832f89dbeba38f5844f5